### PR TITLE
pieusb: Support ProScan 10T and Reflecta CrystalScan 3600

### DIFF
--- a/backend/pieusb.conf.in
+++ b/backend/pieusb.conf.in
@@ -1,9 +1,18 @@
 # pieusb.conf: Configuration file for PIE/Reflecta USB scanner
 # Read man sane-pieusb for documentation
 
-# Autodetect
+# Format
+# usb <vendor-id> <device-id> <model-nr> <has-slide-transport>
+#
+# Autodetect (built-in)
 # Reflecta 6000 Multiple Slide Scanner
-usb 0x05e3 0x0142
+# usb 0x05e3 0x0142 0x3a 0x01
 # Reflecta CrystalScan 7200
+# usb 0x05e3 0x0145 0x30 0x00
 # Reflecta ProScan 7200
-usb 0x05e3 0x0145
+# usb 0x05e3 0x0145 0x36 0x00
+
+# Reflecta ProScan 10T
+
+# Reflecta CrystalScan 3600
+usb 0x05e3 0x0145 0x2e 0x00

--- a/backend/pieusb.h
+++ b/backend/pieusb.h
@@ -80,6 +80,7 @@ struct Pieusb_USB_Device_Entry
     SANE_Word product;		/* USB product identifier */
     SANE_Word model;		/* USB model number */
     SANE_Int device_number;     /* USB device number if the device is present */
+    SANE_Int flags;             /* flags */
 };
 
 extern struct Pieusb_USB_Device_Entry* pieusb_supported_usb_device_list;

--- a/backend/pieusb_scancmd.c
+++ b/backend/pieusb_scancmd.c
@@ -212,7 +212,7 @@ sanei_pieusb_cmd_test_unit_ready(SANE_Int device_number, struct Pieusb_Command_S
 
 /**
  * slide action
- * @param action  SLIDE_NEXT, SLIDE_PREV, SLIDE_LAMP_ON, SLIDE_RELOAD
+ * @param action  SLIDE_NEXT, SLIDE_PREV, SLIDE_INIT, SLIDE_RELOAD
  * @return Pieusb_Command_Status
  */
 

--- a/backend/pieusb_scancmd.h
+++ b/backend/pieusb_scancmd.h
@@ -318,7 +318,7 @@ struct Pieusb_Command_Status {
 typedef struct Pieusb_Scanner_Properties Pieusb_Scanner_Properties;
 
 typedef enum {
-  SLIDE_NEXT = 0x04, SLIDE_PREV = 0x05, SLIDE_LAMP_ON = 0x10, SLIDE_RELOAD = 0x40
+  SLIDE_NEXT = 0x04, SLIDE_PREV = 0x05, SLIDE_INIT = 0x10, SLIDE_RELOAD = 0x40
 } slide_action;
 
 void sanei_pieusb_cmd_slide(SANE_Int device_number, slide_action action, struct Pieusb_Command_Status *status);

--- a/backend/pieusb_specific.h
+++ b/backend/pieusb_specific.h
@@ -193,6 +193,7 @@ struct Pieusb_Device_Definition
       /* USB id's like 0x05e3 0x0145, see pieusb.conf */
     SANE_String version; /* INQUIRY productRevision */
     SANE_Byte model; /* INQUIRY model */
+    SANE_Byte flags; /* pieusb.conf flags */
 
     /* Ranges for various quantities */
     SANE_Range dpi_range;
@@ -315,7 +316,11 @@ struct Pieusb_Scanner
 
 typedef struct Pieusb_Scanner Pieusb_Scanner;
 
-SANE_Status sanei_pieusb_parse_config_line(const char* config_line, SANE_Word* vendor_id, SANE_Word* product_id, SANE_Word* model_number);
+SANE_Status sanei_pieusb_parse_config_line(const char* config_line,
+                                           SANE_Word* vendor_id,
+                                           SANE_Word* product_id,
+                                           SANE_Int* model_number,
+                                           SANE_Int* flags);
 /* sub to sane_start() */
 SANE_Status sanei_pieusb_post (Pieusb_Scanner *scanner,  uint16_t **in_img, int planes);
 void sanei_pieusb_correct_shading(struct Pieusb_Scanner *scanner, struct Pieusb_Read_Buffer *buffer);
@@ -329,8 +334,8 @@ SANE_Status sanei_pieusb_set_frame_from_options(Pieusb_Scanner * scanner);
 void sanei_pieusb_print_options(struct Pieusb_Scanner *scanner);
 /* sub to sane_control_option() and sane_start() */
 int sanei_pieusb_analyse_options(struct Pieusb_Scanner *scanner);
-SANE_Bool sanei_pieusb_supported_device_list_contains(SANE_Word vendor_id, SANE_Word product_id, SANE_Word model_number);
-SANE_Status sanei_pieusb_supported_device_list_add(SANE_Word vendor_id, SANE_Word product_id, SANE_Word model_number);
+SANE_Bool sanei_pieusb_supported_device_list_contains(SANE_Word vendor_id, SANE_Word product_id, SANE_Int model_number, SANE_Int flags);
+SANE_Status sanei_pieusb_supported_device_list_add(SANE_Word vendor_id, SANE_Word product_id, SANE_Int model_number, SANE_Int flags);
 /* sub to sane_init() and sane_open() */
 SANE_Status sanei_pieusb_find_device_callback (const char *devicename);
 /* sub to sane_open() */


### PR DESCRIPTION
Neither of these scanner have an automated slide transport and fail on
respective SCSI commands.

- Add flags parameter to control if automatic slide transport is available
- Reflect flags in pieusb.conf.in
- rename SLIDE_LAMP_ON to SLIDE_INIT
  it fails on scanners without automatic slide transport, so it has
  nothing to do with the lamp.
- run SLIDE_INIT only FLAG_SLIDE_TRANSPORT is set
- pieusb.conf.in: Add Reflecta CrystalScan 3600