### PR TITLE
Removed timestamps from footer to support reproducibility

### DIFF
--- a/tools/sane-desc.c
+++ b/tools/sane-desc.c
@@ -2816,8 +2816,8 @@ html_print_footer (void)
      "<address>\n"
      "<a href=\"http://www.sane-project.org/imprint.html\"\n"
      ">Contact</a>\n" "</address>\n" "<font size=-1>\n");
-  printf ("This page was last updated on %s by sane-desc %s from %s\n",
-	  asctime (localtime (&current_time)), SANE_DESC_VERSION, PACKAGE_STRING);
+  printf ("This page was last updated by sane-desc %s from %s\n",
+	  SANE_DESC_VERSION, PACKAGE_STRING);
   printf ("</font>\n");
   printf ("</body> </html>\n");
 }


### PR DESCRIPTION
Hello, I'm submitting this change in order to further the reproducible builds agenda - which aims to ensure all projects built remain bit-by-bit identical uniformly throughout the package.

In this case, the html_print_footer function (sane-desc.c) was generating different time stamps each time the project was built, and this wasn't allowing this build to be reproducible.